### PR TITLE
[js] add different class when checkbox

### DIFF
--- a/inplaceeditform_bootstrap/static/js/jquery.inplaceeditform.hooks.js
+++ b/inplaceeditform_bootstrap/static/js/jquery.inplaceeditform.hooks.js
@@ -18,7 +18,12 @@
         transformField: function (tags) {
             var self = $.inplaceeditform;
             var field = $(tags).find(self.opts.fieldTypes);
-            field.addClass("form-control");
+            if (field.attr('type') === "checkbox") {
+                field.addClass("form-check-input");
+            }
+            else {
+                field.addClass("form-control");
+            }
             field.css("padding-bottom", "0px");
             field.css("padding-top", "0px");
         }


### PR DESCRIPTION
# What has changed:
* Add a different form class when the field type is a checkbox (the current way is deprecated).
# How to test:
* Check out a place where you use a  boolean field and check if the checkbox is rendered correctly. If so, the fix was successful.
